### PR TITLE
Add Nix support for benchmarks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,43 @@
+let
+  fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
+
+  nixpkgs = fetchNixpkgs {
+    rev = "804060ff9a79ceb0925fe9ef79ddbf564a225d47";
+
+    sha256 = "01pb6p07xawi60kshsxxq1bzn8a0y4s5jjqvhkwps4f5xjmmwav3";
+
+    outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
+  };
+
+  config = {
+    packageOverrides = pkgs: {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: {
+          dhall =
+            pkgs.haskell.lib.failOnAllWarnings
+              (pkgs.haskell.lib.justStaticExecutables
+                (haskellPackagesNew.callPackage ./nix/dhall.nix { })
+              );
+
+          formatting = haskellPackagesOld.formatting_6_3_0;
+
+          prettyprinter = haskellPackagesOld.prettyprinter_1_2_0_1;
+        };
+      };
+    };
+  };
+
+  pkgs =
+    import nixpkgs { inherit config; };
+
+  # Derivation that trivially depends on the current directory so that Hydra's
+  # pull request builder always posts a GitHub status on each revision
+  pwd = pkgs.runCommand "pwd" { here = ./.; } "touch $out";
+
+in
+  { inherit pwd;
+
+    inherit (pkgs.haskellPackages) dhall;
+
+    shell = (pkgs.haskell.lib.doBenchmark pkgs.haskellPackages.dhall).env;
+  }

--- a/nix/dhall.nix
+++ b/nix/dhall.nix
@@ -1,10 +1,10 @@
 { mkDerivation, ansi-terminal, base, bytestring, case-insensitive
-, containers, contravariant, cryptonite, deepseq, directory
-, doctest, exceptions, filepath, formatting, haskeline, http-client
-, http-client-tls, insert-ordered-containers, lens-family-core
-, megaparsec, memory, mtl, optparse-applicative, parsers
-, prettyprinter, prettyprinter-ansi-terminal, repline, scientific
-, stdenv, tasty, tasty-hunit, text, transformers
+, containers, contravariant, criterion, cryptonite, deepseq
+, directory, doctest, exceptions, filepath, formatting, haskeline
+, http-client, http-client-tls, insert-ordered-containers
+, lens-family-core, megaparsec, memory, mtl, optparse-applicative
+, parsers, prettyprinter, prettyprinter-ansi-terminal, repline
+, scientific, stdenv, tasty, tasty-hunit, text, transformers
 , unordered-containers, vector
 }:
 mkDerivation {
@@ -28,6 +28,9 @@ mkDerivation {
   testHaskellDepends = [
     base deepseq doctest insert-ordered-containers prettyprinter tasty
     tasty-hunit text vector
+  ];
+  benchmarkHaskellDepends = [
+    base containers criterion directory text
   ];
   description = "A configuration language guaranteed to terminate";
   license = stdenv.lib.licenses.bsd3;

--- a/release.nix
+++ b/release.nix
@@ -1,41 +1,5 @@
 let
-  fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
-
-  nixpkgs = fetchNixpkgs {
-    rev = "804060ff9a79ceb0925fe9ef79ddbf564a225d47";
-
-    sha256 = "01pb6p07xawi60kshsxxq1bzn8a0y4s5jjqvhkwps4f5xjmmwav3";
-
-    outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
-  };
-
-  config = {
-    packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override {
-        overrides = haskellPackagesNew: haskellPackagesOld: {
-          dhall =
-            pkgs.haskell.lib.failOnAllWarnings
-              (pkgs.haskell.lib.justStaticExecutables
-                (haskellPackagesNew.callPackage ./nix/dhall.nix { })
-              );
-
-          formatting = haskellPackagesOld.formatting_6_3_0;
-
-          prettyprinter = haskellPackagesOld.prettyprinter_1_2_0_1;
-        };
-      };
-    };
-  };
-
-  pkgs =
-    import nixpkgs { inherit config; };
-
-  # Derivation that trivially depends on the current directory so that Hydra's
-  # pull request builder always posts a GitHub status on each revision
-  pwd = pkgs.runCommand "pwd" { here = ./.; } "touch $out";
+  default = (import ./default.nix);
 
 in
-  { inherit pwd;
-
-    inherit (pkgs.haskellPackages) dhall;
-  }
+  { inherit (default) pwd dhall; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix).dhall.env
+(import ./default.nix).shell


### PR DESCRIPTION
This doesn't (yet) run or build the benchmarks in CI due to the long time
to execute all of them, but this does add them to the `shell.nix` so that
they can be run using local development